### PR TITLE
Derive PartialEq and Eq for AstNode and refactor BinaryOperator

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,23 +1,3 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BinaryOperator {
-    Add,      // +
-    Subtract, // -
-    Multiply, // *
-    Divide,   // /
-    Modulo,   // %
-
-    Equal,          // ==
-    NotEqual,       // !=
-    LessThan,       // <
-    LessThanOrEqual,// <=
-    GreaterThan,    // >
-    GreaterThanOrEqual, // >=
-
-    LogicalAnd, // &&
-    LogicalOr,  // ||
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AstNode {
     Program(Vec<AstNode>),
     StructDef {
@@ -58,4 +38,21 @@ pub enum AstNode {
     Number(i64),
     String(String),
     Return(Box<AstNode>),
+}
+pub enum BinaryOperator {
+    Add,      // +
+    Subtract, // -
+    Multiply, // *
+    Divide,   // /
+    Modulo,   // %
+
+    Equal,          // ==
+    NotEqual,       // !=
+    LessThan,       // <
+    LessThanOrEqual,// <=
+    GreaterThan,    // >
+    GreaterThanOrEqual, // >=
+
+    LogicalAnd, // &&
+    LogicalOr,  // ||
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AstNode {
     Program(Vec<AstNode>),
     StructDef {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,23 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    Add,      // +
+    Subtract, // -
+    Multiply, // *
+    Divide,   // /
+    Modulo,   // %
+
+    Equal,          // ==
+    NotEqual,       // !=
+    LessThan,       // <
+    LessThanOrEqual,// <=
+    GreaterThan,    // >
+    GreaterThanOrEqual, // >=
+
+    LogicalAnd, // &&
+    LogicalOr,  // ||
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AstNode {
     Program(Vec<AstNode>),
     StructDef {
@@ -23,7 +42,7 @@ pub enum AstNode {
         value: Box<AstNode>,
     },
     BinaryOp {
-        op: String,
+        op: BinaryOperator,
         left: Box<AstNode>,
         right: Box<AstNode>,
     },


### PR DESCRIPTION
- Mengganti representasi operator `String` di `AstNode::BinaryOp` dengan enum baru `BinaryOperator` untuk meningkatkan keamanan tipe dan kejelasan.
- Memperbaiki `derive` pada `AstNode` dengan menghapus `Copy` (yang tidak valid karena ada field non-Copy seperti `String`, `Vec`, `Box`) sambil mempertahankan `Debug`, `Clone`, `PartialEq`, `Eq`.
- Menambahkan derive yang sesuai (`Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`) ke enum baru `BinaryOperator`.